### PR TITLE
#17, fixed WMI get falied, the process be locked

### DIFF
--- a/App/GoogleAnalyticsClientDotNet.App.WPF/MainWindow.xaml.cs
+++ b/App/GoogleAnalyticsClientDotNet.App.WPF/MainWindow.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using GoogleAnalyticsClientDotNet.ServiceModel;
-using GoogleAnalyticsClientDotNet.Utility;
 using System;
 using System.Windows;
 using System.Windows.Threading;
@@ -13,8 +12,6 @@ namespace GoogleAnalyticsClientDotNet.App.WPF
     {
         DispatcherTimer timer;
 
-        DeviceInformationService deviceService;
-
         public MainWindow()
         {
             InitializeComponent();
@@ -22,7 +19,6 @@ namespace GoogleAnalyticsClientDotNet.App.WPF
             Loaded += MainWindow_Loaded;
             Unloaded += MainWindow_Unloaded;
             
-            deviceService = new DeviceInformationService();
             App.Service.UserId = GetUserID();
             App.Service.ClientId = Guid.NewGuid().ToString();
         }
@@ -62,7 +58,6 @@ namespace GoogleAnalyticsClientDotNet.App.WPF
             eventData.Label = "Debug_label";
             eventData.ScreenName = "Debug_screenName";
             eventData.UserId = GetUserID();
-            eventData.UserAgent = deviceService.ModelName;
             eventData.ClientId = Guid.NewGuid().ToString();
 
             App.Service.TrackEvent(eventData);

--- a/Library/GoogleAnalyticsClientDotNet.Net45/AnalyticsService.cs
+++ b/Library/GoogleAnalyticsClientDotNet.Net45/AnalyticsService.cs
@@ -1,27 +1,28 @@
 ﻿using GoogleAnalyticsClientDotNet.Utility;
-using System.IO;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace GoogleAnalyticsClientDotNet
 {
     public class AnalyticsService : BaseAnalyticsService
     {
+        private DeviceInformationService deviceService;
+
         protected override void InitializeProcess()
         {
             NetworkTool = new NetworkHelper();
-            DefaultUserAgent = BuildUserAgent();
 
             if (LocalTracker == null)
             {
                 LocalTracker = new FileLocalTracker();
             }
+            
+            deviceService = new DeviceInformationService();
+
+            DefaultUserAgent = BuildUserAgent();
         }
 
         protected override string BuildUserAgent()
         {
-            var device = new DeviceInformationService();
-            return $"Mozilla/5.0 (compatible; MSIE {device.IEVersion}.0; Windows NT {device.OperationSystemVersion}; Trident/{device.TridentVersion}.0)";
+            return $"Mozilla/5.0 (compatible; MSIE {deviceService?.IEVersion}.0; Windows NT {deviceService?.OperationSystemVersion}; Trident/{deviceService?.TridentVersion}.0)";
         }
 
         protected override void Reset()

--- a/Library/GoogleAnalyticsClientDotNet.Net45/Properties/AssemblyInfo.cs
+++ b/Library/GoogleAnalyticsClientDotNet.Net45/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.22")]
-[assembly: AssemblyFileVersion("1.0.0.22")]
+[assembly: AssemblyVersion("1.0.0.23")]
+[assembly: AssemblyFileVersion("1.0.0.23")]

--- a/Library/GoogleAnalyticsClientDotNet.Net45/Utility/DeviceInformationService.cs
+++ b/Library/GoogleAnalyticsClientDotNet.Net45/Utility/DeviceInformationService.cs
@@ -142,24 +142,24 @@ namespace GoogleAnalyticsClientDotNet.Utility
 
         private void Initialize()
         {
-            CancellationTokenSource cancel = new CancellationTokenSource(5000);
-
             Task.Run(() =>
             {
                 try
                 {
-                    SelectQuery query = new SelectQuery(@"Select * from Win32_ComputerSystem");
+                    SelectQuery query = new SelectQuery(@"Select * from Win32_BaseBoard");
 
                     //initialize the searcher with the query it is supposed to execute
                     using (ManagementObjectSearcher searcher = new ManagementObjectSearcher(query))
                     {
+                        searcher.Options.Timeout = TimeSpan.FromSeconds(5);
+
                         //execute the query
                         foreach (System.Management.ManagementObject process in searcher.Get())
                         {
                             //print system info
                             process.Get();
                             SystemManufacturer = $"{process["Manufacturer"]}";
-                            ModelName = $"{process["Model"]}";
+                            ModelName = $"{process["Product"]}";
                         }
                     }
 
@@ -170,7 +170,7 @@ namespace GoogleAnalyticsClientDotNet.Utility
                     Debug.WriteLine(ex);
                     IsInitialized = false;
                 }
-            }, cancel.Token);
+            });
         }
     }
 }

--- a/Library/GoogleAnalyticsClientDotNet.Net45/Utility/DeviceInformationService.cs
+++ b/Library/GoogleAnalyticsClientDotNet.Net45/Utility/DeviceInformationService.cs
@@ -1,7 +1,10 @@
 ﻿using Microsoft.Win32;
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Management;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Windows.Input;
 
 namespace GoogleAnalyticsClientDotNet.Utility
@@ -130,22 +133,44 @@ namespace GoogleAnalyticsClientDotNet.Utility
         }
         #endregion
 
+        public bool IsInitialized { get; private set; } = false;
+
         public DeviceInformationService()
         {
-            SelectQuery query = new SelectQuery(@"Select * from Win32_ComputerSystem");
+            Initialize();
+        }
 
-            //initialize the searcher with the query it is supposed to execute
-            using (ManagementObjectSearcher searcher = new ManagementObjectSearcher(query))
+        private void Initialize()
+        {
+            CancellationTokenSource cancel = new CancellationTokenSource(5000);
+
+            Task.Run(() =>
             {
-                //execute the query
-                foreach (System.Management.ManagementObject process in searcher.Get())
+                try
                 {
-                    //print system info
-                    process.Get();
-                    SystemManufacturer = $"{process["Manufacturer"]}";
-                    ModelName = $"{process["Model"]}";
+                    SelectQuery query = new SelectQuery(@"Select * from Win32_ComputerSystem");
+
+                    //initialize the searcher with the query it is supposed to execute
+                    using (ManagementObjectSearcher searcher = new ManagementObjectSearcher(query))
+                    {
+                        //execute the query
+                        foreach (System.Management.ManagementObject process in searcher.Get())
+                        {
+                            //print system info
+                            process.Get();
+                            SystemManufacturer = $"{process["Manufacturer"]}";
+                            ModelName = $"{process["Model"]}";
+                        }
+                    }
+
+                    IsInitialized = true;
                 }
-            }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine(ex);
+                    IsInitialized = false;
+                }
+            }, cancel.Token);
         }
     }
 }


### PR DESCRIPTION
Before the analysis service send event track, the logic will auto set default UserAgent.
User don't need to set UserAgent again.

Restructure DeviceInformationService structure.
use Task and CancellationTokenSource to handle process be locked.
